### PR TITLE
Apply media queries to the header/nav-links

### DIFF
--- a/Develop/assets/css/style.css
+++ b/Develop/assets/css/style.css
@@ -161,3 +161,21 @@ img {
 .footer__copyright {
     color: #000;
 }
+
+
+/* Media Queries */
+
+@media (max-width: 1015px) {
+    .header {
+        padding: 10px 15px;
+        position: relative;
+    }
+
+    .header__nav {
+        padding: 15px;
+        font-size: 16px;
+        position: absolute;
+        right: 0;
+        top: 16px;
+    }
+}


### PR DESCRIPTION
I applied media queries when the viewport width is <= to 1015px. I reduced the font size of the nav-links and adjusted the padding setting in both the nav and header. I applied absolute positioning relative to the header container. 


```CSS
@media (max-width: 1015px) {
    .header {
        padding: 10px 15px;
        position: relative;
    }

    .header__nav {
        padding: 15px;
        font-size: 16px;
        position: absolute;
        right: 0;
        top: 16px;
    }
}
```